### PR TITLE
Require the user to accept terms and conditions if configured to

### DIFF
--- a/app/scripts-browserify/auth.js
+++ b/app/scripts-browserify/auth.js
@@ -17,10 +17,19 @@ $(function() {
   }, lock(), verify());
 
   function lock() {
+    let languageDictionary = {
+      title: config.siteTitle
+    };
+
+    if (config.auth0.acceptTermsText) {
+      languageDictionary.signUpTerms = config.auth0.acceptTermsText;
+    }
+
     return new Auth0Lock(config.auth0.clientID, config.auth0.domain, {
-      languageDictionary: {
-        title: config.siteTitle
-      },
+      languageDictionary: languageDictionary,
+      // If we've been configured with a path to the terms, we'll require the
+      // user to accept the terms.
+      mustAcceptTerms: !!config.auth0.acceptTermsText,
       theme: {
         logo: '/images/favicons/favicon-96x96.png',
         labeledSubmitButton: false,


### PR DESCRIPTION
#### What does this PR do?
Makes it possible to configure auth0 to require acceptance of terms of services before the user can sign up.

After merge https://github.com/CopenhagenCityArchives/kbh-billeder/pull/11 has to be merged

#### How should this be manually tested?
Could be tested locally, but a final test on beta when https://github.com/CopenhagenCityArchives/kbh-billeder/pull/11 is merged should be ok

#### What are the relevant tickets?
https://reload.atlassian.net/browse/KB-4

