### PR TITLE
Improve map cluster ux

### DIFF
--- a/app/scripts-browserify/map.js
+++ b/app/scripts-browserify/map.js
@@ -1,20 +1,51 @@
+/**
+ * The Map "Controller" that wraps a Google Maps and integrates it with searches.
+ *
+ * The controller is initialized via init() after which calls to update() is
+ * used to load the map with data.
+ *
+ * The map will used hashed search-results (provided via update()) at wide
+ * zoom levels, and detailed asset search-results when zoomed in closer.
+ *
+ * The controller users markerclusterer.js to cluster search-results that are
+ * in proximity. For hash-based results this will be rather few points (as a
+ * hash result already represents a cluster), in this situation the clusterer
+ * counts not the number of points, but the number of points represented by each
+ * hash-result and will thus appear much like if the map actually contained the
+ * number of points represented by each hash result.
+ *
+ * When the user intacts with the map all points are cleared. The map is re-
+ * populated when the user lets go of the map and it becomes idle (see the idle-
+ * event-handler registered in init().
+ */
 var Map = {
   // Start the map off over Copenhagen.
-  center: {
+  mapCenter: {
     lat: 55.6761,
     lng: 12.5683
   },
-  zoomLevel: 12,
+  mapZoomLevel: 12,
 
   // Reference to the google.maps.Map instance created in init().
   googleMap: false,
 
-  // Whether the map has been initialized and has stopped sending events that
-  // indicates the user is interacting with it.
-  mapIsIdle: false,
+  // Whether the map is initializing and searches should not be triggered.
+  isInitializing: true,
+
+  // Whether the user is interacting with the map.
+  mapInMotion: false,
 
   // Reference to current set of markers.
-  clusteredMarkers: undefined,
+  clusteredMarkers: false,
+
+  config: {
+    // The zoom level where we start showing assets instead of hashed buckets.
+    assetZoomLevel: undefined,
+    // The max zoom level we're going to show clusters.
+    clusterMaxZoom: undefined,
+    // The callback to search/index.js we use when the map changes.
+    updateCallback: undefined
+  },
 
   /**
    * Returns an Elastic Search {top_left, bottom_right} bounds object.
@@ -50,10 +81,6 @@ var Map = {
   sync: function(updateSearch, map = this) {
     map.zoomLevel = map.googleMap.getZoom();
     map.center = map.googleMap.getCenter();
-
-    // Indicate that the map is being updated.
-    map.mapIsIdle = false;
-    updateSearch(true, true);
   },
 
   /**
@@ -138,13 +165,18 @@ var Map = {
       });
     }
 
-    let textColor = '#E32166';
-
     // Set up the icons for the clustering.
     // Only allow the clusterer to reval the individual markers if they are not
     // hashes.
+    let textColor = '#E32166';
     let options = {
       minimumClusterSize: itemType === 'hash' ? 1 : 5,
+      clickZoomLevel: itemType === 'hash' ? this.config.assetZoomLevel : -1,
+      // How much a cluster takes up - this is what controls how large a cluster
+      // is on the screen.
+      gridSize: 55,
+      // Zooming in further than this will disable clustering.
+      maxZoom: this.config.clusterMaxZoom,
       styles: [
         {
           textColor: textColor,
@@ -167,41 +199,96 @@ var Map = {
       ],
     };
 
-    if (this.clusteredMarkers) {
-      this.clusteredMarkers.clearMarkers();
-    }
-    this.clusteredMarkers = new MarkerClusterer(this.googleMap, markers, options);
-    // We've completed our update and we can start listening for changes again.
-    this.mapIsIdle = true;
+
+    let clusteredMarkers = new MarkerClusterer(this.googleMap, markers, options);
+    // Have the clustermarkers remove themselves if the map is touched.
+    google.maps.event.addListenerOnce(this.googleMap, 'bounds_changed', function() {
+      clusteredMarkers.clearMarkers();
+    });
   },
 
-  init: function (updateSearch, center = this.center, zoom = this.zoomLevel) {
+  /**
+   * Validate config and populate object properties
+   *
+   * @param initConfig
+   *   A config object.
+   * @returns Object
+   *   The validated config optionally with defaults injected
+   *
+   * @private
+   */
+  _checkAndProcessConfig: function(initConfig) {
+    // We do a somewhat strict validation because we're pretty sure which
+    // parameters we're going to get in, and flexibility in this situation just
+    // open us up for bugs.
+    if (!initConfig.updateCallback) {
+      throw new Error('Could not initialize map controller, missing updateCallback');
+    }
+    this.config.updateCallback = initConfig.updateCallback;
+
+    if (initConfig.assetZoomLevel === undefined) {
+      throw new Error('Could not initialize map controller, missing missing assetZoomLevel');
+    }
+    this.config.assetZoomLevel = initConfig.assetZoomLevel;
+
+    if (initConfig.clusterMaxZoom === undefined) {
+      throw new Error('Could not initialize map controller, missing missing clusterMaxZoom');
+    }
+    this.config.clusterMaxZoom = initConfig.clusterMaxZoom;
+
+    // Read in some optional configurations.
+    if (initConfig.center !== undefined) {
+      this.center = initConfig.center;
+    }
+
+    if (initConfig.zoomLevel !== undefined) {
+      this.zoomLevel = initConfig.zoomLevel;
+    }
+  },
+
+  init: function (initConfig) {
+    // Validate config and initialize som this.* properties if available.
+    this._checkAndProcessConfig(initConfig);
+
     this.googleMap = new google.maps.Map(document.getElementById('map'), {
       // Center the map on copenhagen.
-      center: center,
-      zoom: zoom,
+      center: this.mapCenter,
+      zoom: this.mapZoomLevel,
       // Don't require the user to use two fingers when scrolling.
       gestureHandling: 'greedy'
     });
-    // Setup variables for the closure.
-    let timer;
-    let mapIsIdle = this.mapIsIdle;
-    let sync = this.sync;
-    let syncMapRefernce = this;
+
+    // Setup variables for the closures below.
+    let thisReference = this;
+
+    // If any changes is made to the viewport of the map, mark it as in motion.
     google.maps.event.addListener(this.googleMap, 'bounds_changed', function() {
       // Only act on change events if the map was previously reported idle.
-      if (mapIsIdle) {
-        clearTimeout(timer);
-        timer = setTimeout(function(){sync(updateSearch, syncMapRefernce);}, 500);
+      if (!thisReference.mapInMotion) {
+        // Report the map as being non-idle.
+        thisReference.mapInMotion = true;
       }
     });
 
-    google.maps.event.addListenerOnce(this.googleMap, 'idle', function(){
+    // When the map stops moving, sync the state out into our own properties and
+    // trigger a new search.
+    google.maps.event.addListener(this.googleMap, 'idle', function(){
+      // The initialization of the map will throw off a single idle event, so
+      // ignore it and clear the initializing flag.
+      if (thisReference.isInitializing) {
+        thisReference.isInitializing = false;
+        thisReference.mapInMotion = false;
+        return;
+      }
       // The map has settled down and we're ready to react on new changes.
-      mapIsIdle = true;
+      if (thisReference.mapInMotion) {
+        thisReference.mapInMotion = false;
+        thisReference.sync();
+        thisReference.config.updateCallback(true, true);
+      }
     });
 
-    // TODO - make this work
+    // TODO - make this work - KB-354.
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(function(position) {
         var currentLocation = {

--- a/app/scripts-browserify/markerclusterer.js
+++ b/app/scripts-browserify/markerclusterer.js
@@ -13,8 +13,11 @@
  */
 
 /**
- * NOTICE: MarkerClusterer.prototype.calculator_ has been modified to support
+ * Modified for KBH-billeder with the following:
+ * - MarkerClusterer.prototype.calculator_ has been modified to support
  * hash-results.
+ * -  clickZoomLevel - a new property that alters the zoom behaviour when a
+ *    cluster is clicked.
  */
 
 /**
@@ -31,7 +34,6 @@
  * limitations under the License.
  */
 
-
 /**
  * A Marker Clusterer that clusters markers.
  *
@@ -44,6 +46,8 @@
  *                cluster.
  *     'zoomOnClick': (boolean) Whether the default behaviour of clicking on a
  *                    cluster is to zoom into it.
+ *     'clickZoomLevel': (int) when zoomOnClick, a click should zoom to this
+ *                        level.
  *     'imagePath': (string) The base URL where the images representing
  *                  clusters will be found. The full URL will be:
  *                  {imagePath}[1-5].{imageExtension}
@@ -144,6 +148,16 @@ function MarkerClusterer(map, opt_markers, opt_options) {
 
   if (options['zoomOnClick'] != undefined) {
     this.zoomOnClick_ = options['zoomOnClick'];
+  }
+
+  /**
+   * @type {int}
+   * @private
+   */
+  this.clickZoomLevel_ = -1;
+
+  if (options['clickZoomLevel'] != undefined) {
+    this.clickZoomLevel_ = options['clickZoomLevel'];
   }
 
   /**
@@ -303,6 +317,18 @@ MarkerClusterer.prototype.getStyles = function() {
  */
 MarkerClusterer.prototype.isZoomOnClick = function() {
   return this.zoomOnClick_;
+};
+
+/**
+ * How far to zoom on click.
+ *
+ * When isZoomOnClick is set, zoom to this zoom-level instead of a bounding box
+ * around the cluster.
+ *
+ * @return {int} the zoom-level. -1 if disabled.
+ */
+MarkerClusterer.prototype.getClickZoomLevel = function() {
+  return this.clickZoomLevel_;
 };
 
 /**
@@ -1077,8 +1103,14 @@ ClusterIcon.prototype.triggerClusterClick = function() {
   google.maps.event.trigger(markerClusterer.map_, 'clusterclick', this.cluster_);
 
   if (markerClusterer.isZoomOnClick()) {
-    // Zoom into the cluster.
-    this.map_.fitBounds(this.cluster_.getBounds());
+    if (markerClusterer.getClickZoomLevel() >= 0) {
+      // Zoom into the cluster.
+      this.map.setCenter(this.cluster_.getCenter());
+      this.map.setZoom(markerClusterer.getClickZoomLevel());
+    } else {
+      // Zoom into the cluster.
+      this.map_.fitBounds(this.cluster_.getBounds());
+    }
   }
 };
 

--- a/app/scripts-browserify/search/index.js
+++ b/app/scripts-browserify/search/index.js
@@ -230,7 +230,7 @@ function initialize() {
       queryBody = helpers.modifySearchQueryBody(queryBody, searchParams);
     }
 
-    let belowAssetZoomLevel = Map.zoomLevel > config.search.assetZoomLevel;
+    let belowAssetZoomLevel = Map.zoomLevel >= config.search.assetZoomLevel;
     const maxAssets = config.search.maxAssetMarkers;
 
     // If we're zoomed in wide enough, use hash-based results.
@@ -355,7 +355,14 @@ function initialize() {
     inflateHistoryState(event.state);
   }, false);
 
-  Map.init(update);
+  // Setup the map with a callback it can use when it needs a new search trigged
+  // and a configuration for when we switch between hash and asset search-
+  // results.
+  Map.init({
+    updateCallback: update,
+    assetZoomLevel: config.search.assetZoomLevel,
+    clusterMaxZoom: config.search.clusterMaxZoom
+  });
 
   // Initialize the search results, either use the history state, or do an
   // update.
@@ -363,7 +370,7 @@ function initialize() {
     update();
   } else {
     update();
-    // TODO - make history work again.
+    // TODO - make history work again. KB-354.
     // Temporarily disabled while we figure out how to store geohashes in the history.
     // inflateHistoryState(history.state);
   }

--- a/lib/config.js
+++ b/lib/config.js
@@ -35,9 +35,11 @@ const defaults = {
   root: rootPath,
   search: {
     path: 'search',
-    // The zoom-level over which we should start showing assets instead of
+    // The zoom-level for which we should start showing assets instead of
     // geo-hashed buckets.
-    assetZoomLevel: 15,
+    assetZoomLevel: 16,
+    // The zoom level at which we should disable clustering.
+    clusterMaxZoom: 19,
     // The size of the hash-buckets, 7 roughly translates to 152m x 152m. See
     // https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geohashgrid-aggregation.html
     geohashPrecision: 7,


### PR DESCRIPTION
- Added a general description for the map controller
- Simplified the map-interaction-detection
  * we now only use bounds_changed for setting the mapInMotion flag which is
    then later used to detect whether we transitioned from motion to idle.
  * Clusters clears them selves now, after instantiating the cluster we create
    a one-time event listener that clears it if bounds_changed is published
- Use the new clickZoomLevel feature of the marker-clusterer to control how far
  we zoom when a hash-cluster is clicked
- Pulled a number of configurations out of map.js / search/index.js into the
  general collections-online config

While this commit fixes a lot, it mainly changes business logic related to
KB-369